### PR TITLE
Update call to getVisitorId()

### DIFF
--- a/Queue/Manager.php
+++ b/Queue/Manager.php
@@ -196,7 +196,7 @@ class Manager
     private function getVisitorIdFromRequest(Tracker\Request $request)
     {
         try {
-            $visitorId = $request->getVisitorId();
+            $visitorId = $request->getVisitorId(true);
         } catch (InvalidRequestParameterException $e) {
             $visitorId = null;
         }


### PR DESCRIPTION
getVisitorId() may cause (sometimes) a db connection if my pull request gets accepted ( https://github.com/matomo-org/matomo/pull/13620 ).

To avoid this db connection when using QueuedTracking, this pr replaces the call to getVisitorId() with getVisitorIdForThirdPartyCookie(). The visitiorId is only used to determine into which queue the request gets inserted, so it does not really matter "which" idVisitor value we use. The call to getVisitorIdForThirdPartyCookie() will never cause a db connection.