### PR TITLE
Add possibility to disable the queued tracking handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+3.3.3
+- Add possibility to ignore queued tracking handler and track request directly into the database
+
+3.3.2
+- Send branded HTML email
+
 3.3.1
 - Support MySQLi adapter
 

--- a/QueuedTracking.php
+++ b/QueuedTracking.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\QueuedTracking;
 
+use Piwik\Common;
 use Piwik\Plugins\QueuedTracking\Queue\Backend\MySQL;
 use Piwik\Plugins\QueuedTracking\Tracker\Handler;
 
@@ -48,6 +49,11 @@ class QueuedTracking extends \Piwik\Plugin
 
     public function replaceHandlerIfQueueIsEnabled(&$handler)
     {
+        $useQueuedTracking = Common::getRequestVar('queuedtracking', 1, 'int');
+        if (!$useQueuedTracking) {
+            return;
+        }
+
         $settings = Queue\Factory::getSettings();
 
         if ($settings->queueEnabled->getValue()) {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -112,6 +112,7 @@ __How can I debug in case something goes wrong?__
 * Set the option `-vvv` when processing via `./console queuedtracking:process -vvv` to enable the tracker debug mode for this run. This will print detailed information to screen.
 * Enable tracker mode in `config.ini.php` via `[Tracker] debug=1` if processing requests during tracking is enabled.
 * Use the command `./console queuedtracking:print-queued-requests` to view the next requests to process in each queue. If you execute this command twice within 1-10 minutes, and it outputs the same, the queue is not being processed most likely indicating a problem.
+* You can add the tracking parameter `&queuedtracking=0` to the tracking request to insert a tracking request directly into the database instead of into the queued tracking handler
 
 __I am using the Log Importer in combination with Queued Tracking, is there something to consider?__
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "QueuedTracking",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "description": "Scale your large traffic Piwik service by queuing tracking requests in Redis for better performance. ",
     "theme": false,
     "keywords": ["tracker", "tracking", "queue", "redis"],


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/12340

Useful for log importer, but also when needing to debug tracking requests or have automated tests that check if the tracking works etc.

By appending `&queuedtracking=0` to a tracking request, the tracking request will be executed directly and not put into the queue

fyi @mattab 