### PR TITLE
Feature suggestion: compress tracking data before sending it to Redis

### DIFF
--- a/Queue/Backend/Redis.php
+++ b/Queue/Backend/Redis.php
@@ -101,7 +101,7 @@ class Redis implements Backend
         $this->connectIfNeeded();
 
         foreach ($values as $value) {
-            $this->redis->rPush($key, gzdeflate($value));
+            $this->redis->rPush($key, gzcompress($value));
         }
 
         // usually we would simply do call_user_func_array(array($redis, 'rPush'), $values); as rpush supports multiple values
@@ -119,7 +119,14 @@ class Redis implements Backend
         $this->connectIfNeeded();
         $values = $this->redis->lRange($key, 0, $numValues - 1);
         foreach($values as $key => $value) {
-            $values[$key] = gzinflate($value);
+            $tmpValue = @gzuncompress($value); // Avoid warning if not compressed
+            
+            // if empty, string is not compressed. Use original value
+            if(empty($tmpValue)) {
+                $values[$key] = $value;
+            } else {
+                $values[$key] = $tmpValue;
+            }
         }
 
         return $values;

--- a/Queue/Backend/Redis.php
+++ b/Queue/Backend/Redis.php
@@ -101,7 +101,7 @@ class Redis implements Backend
         $this->connectIfNeeded();
 
         foreach ($values as $value) {
-            $this->redis->rPush($key, $value);
+            $this->redis->rPush($key, gzdeflate($value));
         }
 
         // usually we would simply do call_user_func_array(array($redis, 'rPush'), $values); as rpush supports multiple values
@@ -118,6 +118,9 @@ class Redis implements Backend
 
         $this->connectIfNeeded();
         $values = $this->redis->lRange($key, 0, $numValues - 1);
+        foreach($values as $key => $value) {
+            $values[$key] = gzinflate($value);
+        }
 
         return $values;
     }
@@ -259,6 +262,7 @@ end';
 
         if (!empty($this->database) || 0 === $this->database) {
             $this->redis->select($this->database);
+            
         }
 
         return $success;

--- a/Queue/Backend/Redis.php
+++ b/Queue/Backend/Redis.php
@@ -269,7 +269,6 @@ end';
 
         if (!empty($this->database) || 0 === $this->database) {
             $this->redis->select($this->database);
-            
         }
 
         return $success;


### PR DESCRIPTION
Hi,

PR introduces compression of tracking data before it is sent to Redis. Decompresses on get operations.

In our matomo environment with constant load (25req/s) and hour-long peaks (500req/s) we saw the following performance improvements for the containers that handles Tracker API (matomo.php) requests:
Pre-compression (c5n.large EC2):
CPU (avg 5 min): 6% of single vCPU
RAM (avg 5 min): 184MB
Response time (avg over 15min): 15.5ms

Post-compression:
CPU (avg 5 min): 8% of single vCPU
RAM (avg 5 min): 245MB
Response time (avg over 15min): 13.5ms

In Redis, we saw an decrease in network bytes in/out by 45%. Bytes used for caching was also reduced with the same amount.

Response values for p50, p90 and p95 values decreased, but increased for p99 (60ms to 65ms, 15min avg.).

We did the tests in eu-west-1, while redis was running in zone A, and matomo was running only in zone C, so cross-zone latency would impact this test.

We sampled some tracking requests stored in redis, and average size was ~5.8KB before compression, and ~2KB post-compression.

I hope this provides enough information to consider this PR, let me know if you have questions. We will continue some test-run in production before we decide if we will have this as a permanent change for our environment.


