### PR TITLE
Improve update script to prevent duplicate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+3.3.5
+- Improve update script to first add primary key and then remove index
+
 3.3.4
 - Use primary key instead of a unique index for mysql backend for better replication
 

--- a/Updates/3.3.4.php
+++ b/Updates/3.3.4.php
@@ -30,8 +30,8 @@ class Updates_3_3_4 extends PiwikUpdates
 
     public function getMigrations(Updater $updater)
     {
-        $migration1 = $this->migration->db->dropIndex('queuedtracking_queue', 'unique_queue_key');
-        $migration2 = $this->migration->db->addPrimaryKey('queuedtracking_queue', array('queue_key'));
+        $migration1 = $this->migration->db->addPrimaryKey('queuedtracking_queue', array('queue_key'));
+        $migration2 = $this->migration->db->dropIndex('queuedtracking_queue', 'unique_queue_key');
 
         return array(
             $migration1,

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "QueuedTracking",
-    "version": "3.3.4",
+    "version": "3.3.5",
     "description": "Scale your large traffic Matomo service by queuing tracking requests in Redis or MySQL for better performance and reliability when experiencing peaks.",
     "theme": false,
     "keywords": ["tracker", "tracking", "queue", "redis"],


### PR DESCRIPTION
If we first drop the unique index and then add primary key, we might get a problem that by the time the index was removed and before the primary key was added, a duplicate key exists which then causes the primary key addition to fail.