### PR TITLE
Fix paths to work better with custom plugins directories

### DIFF
--- a/Queue/Backend/Sentinel.php
+++ b/Queue/Backend/Sentinel.php
@@ -14,9 +14,9 @@ use Piwik\Plugins\QueuedTracking\Queue\Backend;
 use Piwik\Tracker;
 use Exception;
 
-include_once PIWIK_INCLUDE_PATH . '/plugins/QueuedTracking/libs/credis/Client.php';
-include_once PIWIK_INCLUDE_PATH . '/plugins/QueuedTracking/libs/credis/Cluster.php';
-include_once PIWIK_INCLUDE_PATH . '/plugins/QueuedTracking/libs/credis/Sentinel.php';
+include_once __DIR__ . '/../../libs/credis/Client.php';
+include_once __DIR__ . '/../../libs/credis/Cluster.php';
+include_once __DIR__ . '/../../libs/credis/Sentinel.php';
 
 class Sentinel extends Redis
 {


### PR DESCRIPTION
Matomo 3.9 introduced new env variables to load plugins from custom directories other than the default `/plugins` folder.

This PR fix paths for some includes to handle better new plugins directories

Fixes #109 